### PR TITLE
Add flexible install location for Android app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.moodday">
+  package="com.moodday"
+  android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
## Summary
- allow the Android package to be installed in an automatic location if internal storage is constrained

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab35e0fb0832ab85f17b8bfcbc4fb)