### PR TITLE
Define Android install location as auto

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.moodday">
+  package="com.moodday"
+  android:installLocation="auto">
 
     <uses-permission android:name="android.permission.INTERNET" />
 


### PR DESCRIPTION
## Summary
- set the Android manifest to prefer automatic install location to avoid storage issues during deployment

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab35e0fb0832ab85f17b8bfcbc4fb)